### PR TITLE
Updates to base Olinda version

### DIFF
--- a/notebooks/demo_quick.ipynb
+++ b/notebooks/demo_quick.ipynb
@@ -2,29 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-05-16 14:40:53.276894: E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
-      "2024-05-16 14:40:53.276932: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
-      "2024-05-16 14:40:53.277528: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
-      "2024-05-16 14:40:53.281158: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
-      "To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2024-05-16 14:40:53.968656: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using TensorFlow backend\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from olinda.distillation import distill"
    ]
@@ -40,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,8 +39,8 @@
     "    ) -> None:\n",
     "        \"\"\"Init.\"\"\"\n",
     "        super().__init__()\n",
-    "        self.conv1 = nn.Conv2d(32, 32, kernel_size=3, padding=0, stride=3)\n",
-    "        self.fc1 = nn.Linear(100, 512)\n",
+    "        #self.conv1 = nn.Conv2d(32, 32, kernel_size=3, padding=0, stride=3)\n",
+    "        self.fc1 = nn.Linear(1024, 512)\n",
     "        self.fc2 = nn.Linear(512, 256)\n",
     "        self.fc3 = nn.Linear(256, 1)\n",
     "\n",
@@ -75,11 +55,11 @@
     "        Returns:\n",
     "            Any: model output\n",
     "        \"\"\"\n",
-    "        x = self.conv1(x)\n",
-    "        x = F.relu(x)\n",
+    "        #x = self.conv1(x)\n",
+    "        #x = F.relu(x)\n",
     "\n",
     "        # flattening while keeping the batch axis\n",
-    "        x = x.view(x.shape[0], -1)\n",
+    "        #x = x.view(x.shape[0], -1)\n",
     "        x = self.fc1(x)\n",
     "        x = F.relu(x)\n",
     "        x = self.fc2(x)\n",
@@ -107,79 +87,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Featurizing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [03:00<00:00, 17.30it/s]\n",
-      "Creating model output: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [01:57<00:00, 26.54it/s]\n",
-      "2024-05-16 14:46:14.801850: E external/local_xla/xla/stream_executor/cuda/cuda_driver.cc:274] failed call to cuInit: CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected\n",
-      "2024-05-16 14:46:14.801877: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:129] retrieving CUDA diagnostic information for host: jason-Legion-5-15ACH6\n",
-      "2024-05-16 14:46:14.801884: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:136] hostname: jason-Legion-5-15ACH6\n",
-      "2024-05-16 14:46:14.801920: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:159] libcuda reported version is: 550.54.15\n",
-      "2024-05-16 14:46:14.801937: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:163] kernel reported version is: 550.54.15\n",
-      "2024-05-16 14:46:14.801942: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:241] kernel version seems to match DSO: 550.54.15\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reloading Tuner from ./trials/tuner0.json\n",
-      "Epoch 1/3\n",
-      "3125/3125 [==============================] - 235s 75ms/step - loss: 0.1133 - val_loss: 1.5815e-04\n",
-      "Epoch 2/3\n",
-      "3125/3125 [==============================] - 226s 72ms/step - loss: 1.4971e-04 - val_loss: 1.3651e-04\n",
-      "Epoch 3/3\n",
-      "3125/3125 [==============================] - 225s 72ms/step - loss: 1.3610e-04 - val_loss: 1.3184e-04\n",
-      "Best epoch: 3\n",
-      "Epoch 1/3\n",
-      "3125/3125 [==============================] - 224s 72ms/step - loss: 0.2662 - val_loss: 1.5401e-04\n",
-      "Epoch 2/3\n",
-      "3125/3125 [==============================] - 224s 72ms/step - loss: 1.4310e-04 - val_loss: 1.3508e-04\n",
-      "Epoch 3/3\n",
-      "3125/3125 [==============================] - 224s 72ms/step - loss: 1.3538e-04 - val_loss: 1.3187e-04\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-05-16 15:09:00.650862: I tensorflow/core/grappler/devices.cc:66] Number of eligible GPUs (core count >= 8, compute capability >= 0.0): 0\n",
-      "2024-05-16 15:09:00.650963: I tensorflow/core/grappler/clusters/single_machine.cc:361] Starting new session\n",
-      "2024-05-16 15:09:00.697568: I tensorflow/core/grappler/devices.cc:66] Number of eligible GPUs (core count >= 8, compute capability >= 0.0): 0\n",
-      "2024-05-16 15:09:00.697666: I tensorflow/core/grappler/clusters/single_machine.cc:361] Starting new session\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#featurizer, student_model = distill(model, test=True, clean=True)\n",
-    "featurizer, student_model = distill(model, test=True, clean=True, small_data=True) #An even smaller test set"
+    "featurizer, student_model = distill(model, clean=True, num_data=300) #An even smaller test set"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[-0.020981745794415474]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "smiles_list = featurizer.featurize([\"CCCOC\"])\n",
-    "student_model(smiles_list)"
+    "x = featurizer.featurize([\"CCCOC\"])\n",
+    "student_model(x)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/notebooks/demo_quick.ipynb
+++ b/notebooks/demo_quick.ipynb
@@ -2,11 +2,32 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-06-05 22:31:21.525909: E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+      "2024-06-05 22:31:21.525942: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+      "2024-06-05 22:31:21.526565: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "2024-06-05 22:31:21.530377: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+      "To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2024-06-05 22:31:22.195855: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using TensorFlow backend\n"
+     ]
+    }
+   ],
    "source": [
-    "from olinda.distillation import distill"
+    "from olinda.distillation import distill\n",
+    "from olinda.featurizer import MorganFeaturizer"
    ]
   },
   {
@@ -20,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,37 +108,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Featurizing: 100%|████████████████████████████████| 9/9 [00:00<00:00, 53.47it/s]\n",
+      "Creating model output: 100%|██████████████████████| 9/9 [00:00<00:00, 25.78it/s]\n",
+      "2024-06-05 22:31:27.916838: E external/local_xla/xla/stream_executor/cuda/cuda_driver.cc:274] failed call to cuInit: CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected\n",
+      "2024-06-05 22:31:27.916860: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:129] retrieving CUDA diagnostic information for host: jason-Legion-5-15ACH6\n",
+      "2024-06-05 22:31:27.916865: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:136] hostname: jason-Legion-5-15ACH6\n",
+      "2024-06-05 22:31:27.916897: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:159] libcuda reported version is: 550.54.15\n",
+      "2024-06-05 22:31:27.916921: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:163] kernel reported version is: 550.54.15\n",
+      "2024-06-05 22:31:27.916926: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:241] kernel version seems to match DSO: 550.54.15\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reloading Tuner from ./trials/tuner0.json\n",
+      "Epoch 1/3\n",
+      "9/9 [==============================] - 1s 93ms/step - loss: 44.4484 - val_loss: 0.0206\n",
+      "Epoch 2/3\n",
+      "9/9 [==============================] - 1s 79ms/step - loss: 0.0117 - val_loss: 0.0036\n",
+      "Epoch 3/3\n",
+      "9/9 [==============================] - 1s 76ms/step - loss: 0.0076 - val_loss: 0.0026\n",
+      "Best epoch: 3\n",
+      "Epoch 1/3\n",
+      "9/9 [==============================] - 1s 89ms/step - loss: 29.2386 - val_loss: 0.5343\n",
+      "Epoch 2/3\n",
+      "9/9 [==============================] - 1s 76ms/step - loss: 0.1644 - val_loss: 0.0243\n",
+      "Epoch 3/3\n",
+      "9/9 [==============================] - 1s 76ms/step - loss: 0.0248 - val_loss: 0.0132\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-06-05 22:31:33.655249: I tensorflow/core/grappler/devices.cc:66] Number of eligible GPUs (core count >= 8, compute capability >= 0.0): 0\n",
+      "2024-06-05 22:31:33.655337: I tensorflow/core/grappler/clusters/single_machine.cc:361] Starting new session\n",
+      "2024-06-05 22:31:33.697589: I tensorflow/core/grappler/devices.cc:66] Number of eligible GPUs (core count >= 8, compute capability >= 0.0): 0\n",
+      "2024-06-05 22:31:33.697701: I tensorflow/core/grappler/clusters/single_machine.cc:361] Starting new session\n"
+     ]
+    }
+   ],
    "source": [
     "#featurizer, student_model = distill(model, test=True, clean=True)\n",
-    "featurizer, student_model = distill(model, clean=True, num_data=300) #An even smaller test set"
+    "student_model = distill(model, clean=True, num_data=300) #An even smaller test set"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[-0.049883883446455]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "x = featurizer.featurize([\"CCCOC\"])\n",
+    "x = MorganFeaturizer().featurize([\"CCCOC\"])\n",
     "student_model(x)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/demo_quick.ipynb
+++ b/notebooks/demo_quick.ipynb
@@ -2,29 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-06-05 22:31:21.525909: E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
-      "2024-06-05 22:31:21.525942: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
-      "2024-06-05 22:31:21.526565: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
-      "2024-06-05 22:31:21.530377: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
-      "To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2024-06-05 22:31:22.195855: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using TensorFlow backend\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from olinda.distillation import distill\n",
     "from olinda.featurizer import MorganFeaturizer"
@@ -41,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +40,6 @@
     "    ) -> None:\n",
     "        \"\"\"Init.\"\"\"\n",
     "        super().__init__()\n",
-    "        #self.conv1 = nn.Conv2d(32, 32, kernel_size=3, padding=0, stride=3)\n",
     "        self.fc1 = nn.Linear(1024, 512)\n",
     "        self.fc2 = nn.Linear(512, 256)\n",
     "        self.fc3 = nn.Linear(256, 1)\n",
@@ -76,11 +55,6 @@
     "        Returns:\n",
     "            Any: model output\n",
     "        \"\"\"\n",
-    "        #x = self.conv1(x)\n",
-    "        #x = F.relu(x)\n",
-    "\n",
-    "        # flattening while keeping the batch axis\n",
-    "        #x = x.view(x.shape[0], -1)\n",
     "        x = self.fc1(x)\n",
     "        x = F.relu(x)\n",
     "        x = self.fc2(x)\n",
@@ -108,79 +82,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Featurizing: 100%|████████████████████████████████| 9/9 [00:00<00:00, 53.47it/s]\n",
-      "Creating model output: 100%|██████████████████████| 9/9 [00:00<00:00, 25.78it/s]\n",
-      "2024-06-05 22:31:27.916838: E external/local_xla/xla/stream_executor/cuda/cuda_driver.cc:274] failed call to cuInit: CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected\n",
-      "2024-06-05 22:31:27.916860: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:129] retrieving CUDA diagnostic information for host: jason-Legion-5-15ACH6\n",
-      "2024-06-05 22:31:27.916865: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:136] hostname: jason-Legion-5-15ACH6\n",
-      "2024-06-05 22:31:27.916897: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:159] libcuda reported version is: 550.54.15\n",
-      "2024-06-05 22:31:27.916921: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:163] kernel reported version is: 550.54.15\n",
-      "2024-06-05 22:31:27.916926: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:241] kernel version seems to match DSO: 550.54.15\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reloading Tuner from ./trials/tuner0.json\n",
-      "Epoch 1/3\n",
-      "9/9 [==============================] - 1s 93ms/step - loss: 44.4484 - val_loss: 0.0206\n",
-      "Epoch 2/3\n",
-      "9/9 [==============================] - 1s 79ms/step - loss: 0.0117 - val_loss: 0.0036\n",
-      "Epoch 3/3\n",
-      "9/9 [==============================] - 1s 76ms/step - loss: 0.0076 - val_loss: 0.0026\n",
-      "Best epoch: 3\n",
-      "Epoch 1/3\n",
-      "9/9 [==============================] - 1s 89ms/step - loss: 29.2386 - val_loss: 0.5343\n",
-      "Epoch 2/3\n",
-      "9/9 [==============================] - 1s 76ms/step - loss: 0.1644 - val_loss: 0.0243\n",
-      "Epoch 3/3\n",
-      "9/9 [==============================] - 1s 76ms/step - loss: 0.0248 - val_loss: 0.0132\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-06-05 22:31:33.655249: I tensorflow/core/grappler/devices.cc:66] Number of eligible GPUs (core count >= 8, compute capability >= 0.0): 0\n",
-      "2024-06-05 22:31:33.655337: I tensorflow/core/grappler/clusters/single_machine.cc:361] Starting new session\n",
-      "2024-06-05 22:31:33.697589: I tensorflow/core/grappler/devices.cc:66] Number of eligible GPUs (core count >= 8, compute capability >= 0.0): 0\n",
-      "2024-06-05 22:31:33.697701: I tensorflow/core/grappler/clusters/single_machine.cc:361] Starting new session\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#featurizer, student_model = distill(model, test=True, clean=True)\n",
-    "student_model = distill(model, clean=True, num_data=300) #An even smaller test set"
+    "#student_model = distill(model, clean=True)\n",
+    "student_model = distill(model, clean=True, num_data=10000) #An even smaller test set"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[-0.049883883446455]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "x = MorganFeaturizer().featurize([\"CCCOC\"])\n",
     "student_model(x)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/demo_quick.ipynb
+++ b/notebooks/demo_quick.ipynb
@@ -2,9 +2,29 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-05-16 14:40:53.276894: E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+      "2024-05-16 14:40:53.276932: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+      "2024-05-16 14:40:53.277528: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "2024-05-16 14:40:53.281158: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+      "To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2024-05-16 14:40:53.968656: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using TensorFlow backend\n"
+     ]
+    }
+   ],
    "source": [
     "from olinda.distillation import distill"
    ]
@@ -20,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,17 +107,91 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Featurizing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [03:00<00:00, 17.30it/s]\n",
+      "Creating model output: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3125/3125 [01:57<00:00, 26.54it/s]\n",
+      "2024-05-16 14:46:14.801850: E external/local_xla/xla/stream_executor/cuda/cuda_driver.cc:274] failed call to cuInit: CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected\n",
+      "2024-05-16 14:46:14.801877: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:129] retrieving CUDA diagnostic information for host: jason-Legion-5-15ACH6\n",
+      "2024-05-16 14:46:14.801884: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:136] hostname: jason-Legion-5-15ACH6\n",
+      "2024-05-16 14:46:14.801920: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:159] libcuda reported version is: 550.54.15\n",
+      "2024-05-16 14:46:14.801937: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:163] kernel reported version is: 550.54.15\n",
+      "2024-05-16 14:46:14.801942: I external/local_xla/xla/stream_executor/cuda/cuda_diagnostics.cc:241] kernel version seems to match DSO: 550.54.15\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reloading Tuner from ./trials/tuner0.json\n",
+      "Epoch 1/3\n",
+      "3125/3125 [==============================] - 235s 75ms/step - loss: 0.1133 - val_loss: 1.5815e-04\n",
+      "Epoch 2/3\n",
+      "3125/3125 [==============================] - 226s 72ms/step - loss: 1.4971e-04 - val_loss: 1.3651e-04\n",
+      "Epoch 3/3\n",
+      "3125/3125 [==============================] - 225s 72ms/step - loss: 1.3610e-04 - val_loss: 1.3184e-04\n",
+      "Best epoch: 3\n",
+      "Epoch 1/3\n",
+      "3125/3125 [==============================] - 224s 72ms/step - loss: 0.2662 - val_loss: 1.5401e-04\n",
+      "Epoch 2/3\n",
+      "3125/3125 [==============================] - 224s 72ms/step - loss: 1.4310e-04 - val_loss: 1.3508e-04\n",
+      "Epoch 3/3\n",
+      "3125/3125 [==============================] - 224s 72ms/step - loss: 1.3538e-04 - val_loss: 1.3187e-04\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-05-16 15:09:00.650862: I tensorflow/core/grappler/devices.cc:66] Number of eligible GPUs (core count >= 8, compute capability >= 0.0): 0\n",
+      "2024-05-16 15:09:00.650963: I tensorflow/core/grappler/clusters/single_machine.cc:361] Starting new session\n",
+      "2024-05-16 15:09:00.697568: I tensorflow/core/grappler/devices.cc:66] Number of eligible GPUs (core count >= 8, compute capability >= 0.0): 0\n",
+      "2024-05-16 15:09:00.697666: I tensorflow/core/grappler/clusters/single_machine.cc:361] Starting new session\n"
+     ]
+    }
+   ],
+   "source": [
+    "#featurizer, student_model = distill(model, test=True, clean=True)\n",
+    "featurizer, student_model = distill(model, test=True, clean=True, small_data=True) #An even smaller test set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[-0.020981745794415474]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "smiles_list = featurizer.featurize([\"CCCOC\"])\n",
+    "student_model(smiles_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "student_model = distill(model, test=True, clean=True)"
-   ]
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.13 ('olinda')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -111,9 +205,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.19"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "1a99ec2c7e6dcf550e2bfe1082b4340c44b0e5bb78e6817969edc43085c4abe7"
@@ -121,5 +214,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ tensorflow-metal = { version = "^0.5.0", markers = "sys_platform == 'darwin' and
 keras-tuner = "^1.1.3"
 autokeras = "^1.0.20"
 ersilia = "^0.1.31"
-tf2onnx
-onnxruntime
+tf2onnx = ">=1.16.1"
+onnxruntime = ">=1.17.3"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,19 +17,19 @@ pydantic = "^1.9.2"
 xdg = "^5.1.1"
 joblib = "^1.1.0"
 cbor2 = "^5.4.3"
-pandas = "^1.4.4"
+#pandas = "^1.4.4"
 cbor = "^1.0.0"
 numpy = "^1.23.4"
 lap = { git = "https://github.com/gatagat/lap.git", branch = "new-packaging" }
 griddify = "^0.0.1"
 rdkit = { version = "^2022.3.5", markers = "sys_platform != 'darwin' or  platform_machine != 'arm64'" }
 rdkit-pypi = { version = "^2022.3.5", markers = "sys_platform == 'darwin' and platform_machine == 'arm64'" }
-tensorflow = { version = "^2.9", markers = "sys_platform != 'darwin' or platform_machine != 'arm64'" }
+tensorflow = { version = "^2.9, <2.16.0", markers = "sys_platform != 'darwin' or platform_machine != 'arm64'" }
 tensorflow-macos = { version = "^2.9", markers = "sys_platform == 'darwin' and platform_machine == 'arm64'" }
 tensorflow-metal = { version = "^0.5.0", markers = "sys_platform == 'darwin' and platform_machine == 'arm64'" }
 keras-tuner = "^1.1.3"
 autokeras = "^1.0.20"
-ersilia = "^0.1.1"
+ersilia = "^0.1.31"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ tensorflow-metal = { version = "^0.5.0", markers = "sys_platform == 'darwin' and
 keras-tuner = "^1.1.3"
 autokeras = "^1.0.20"
 ersilia = "^0.1.31"
+tf2onnx
+onnxruntime
 
 
 [tool.poetry.dev-dependencies]

--- a/src/olinda/data/featurized_smiles.py
+++ b/src/olinda/data/featurized_smiles.py
@@ -22,7 +22,6 @@ class FeaturizedSmilesDM(pl.LightningDataModule):
         num_workers: int = 1,
         transform: Optional[Any] = None,
         target_transform: Optional[Any] = None,
-        small_data: bool = False,
     ) -> None:
         """Init.
 
@@ -41,7 +40,6 @@ class FeaturizedSmilesDM(pl.LightningDataModule):
         self.num_workers = num_workers
         self.transform = transform
         self.target_transform = target_transform
-        self.small_data = small_data
         
 
     def setup(self: "FeaturizedSmilesDM", stage: Optional[str]) -> None:
@@ -65,18 +63,12 @@ class FeaturizedSmilesDM(pl.LightningDataModule):
 
         with open(file_path, "rb") as fp:
             dataset_size = calculate_cbor_size(fp)
-
+        #print(dataset_size)
         if stage == "train":
-            if self.small_data:
-                self.train_dataset_size = 100
-            else:
-                self.train_dataset_size = dataset_size
+            self.train_dataset_size = dataset_size
             shuffle = 5000
         elif stage == "val":
-            if self.small_data:
-                self.val_dataset_size = 100
-            else:
-                self.val_dataset_size = dataset_size // 10
+            self.val_dataset_size = dataset_size // 10
             shuffle = None
 
         self.dataset = wds.DataPipeline(

--- a/src/olinda/data/featurized_smiles.py
+++ b/src/olinda/data/featurized_smiles.py
@@ -22,6 +22,7 @@ class FeaturizedSmilesDM(pl.LightningDataModule):
         num_workers: int = 1,
         transform: Optional[Any] = None,
         target_transform: Optional[Any] = None,
+        small_data: bool = False,
     ) -> None:
         """Init.
 
@@ -40,6 +41,8 @@ class FeaturizedSmilesDM(pl.LightningDataModule):
         self.num_workers = num_workers
         self.transform = transform
         self.target_transform = target_transform
+        self.small_data = small_data
+        
 
     def setup(self: "FeaturizedSmilesDM", stage: Optional[str]) -> None:
         """Setup dataloaders.
@@ -64,10 +67,16 @@ class FeaturizedSmilesDM(pl.LightningDataModule):
             dataset_size = calculate_cbor_size(fp)
 
         if stage == "train":
-            self.train_dataset_size = dataset_size
+            if self.small_data:
+                self.train_dataset_size = 100
+            else:
+                self.train_dataset_size = dataset_size
             shuffle = 5000
         elif stage == "val":
-            self.val_dataset_size = dataset_size // 10
+            if self.small_data:
+                self.val_dataset_size = 100
+            else:
+                self.val_dataset_size = dataset_size // 10
             shuffle = None
 
         self.dataset = wds.DataPipeline(

--- a/src/olinda/data/generic_model_output.py
+++ b/src/olinda/data/generic_model_output.py
@@ -113,7 +113,6 @@ class GenericOutputDM(pl.LightningDataModule):
         )
 
         loader.length = (self.train_dataset_size * self.num_workers) // self.batch_size
-
         return loader
 
     def val_dataloader(self: "GenericOutputDM") -> DataLoader:

--- a/src/olinda/data/reference_smiles.py
+++ b/src/olinda/data/reference_smiles.py
@@ -30,6 +30,7 @@ class ReferenceSmilesDM(pl.LightningDataModule):
         num_workers: int = 1,
         transform: Optional[Any] = None,
         target_transform: Optional[Any] = None,
+        small_data: bool = False,
     ) -> None:
         """Init.
 
@@ -47,6 +48,7 @@ class ReferenceSmilesDM(pl.LightningDataModule):
         self.num_workers = num_workers
         self.transform = transform
         self.target_transform = target_transform
+        self.small_data = small_data
 
     def prepare_data(self: "ReferenceSmilesDM") -> None:
         """Prepare data."""
@@ -109,7 +111,10 @@ class ReferenceSmilesDM(pl.LightningDataModule):
             stage (Optional[str]): Optional pipeline state
         """
         if stage == "train":
-            self.dataset_size = 1999380
+            if self.small_data:
+                self.dataset_size = 100
+            else:
+                self.dataset_size = 1999380
             shuffle = 5000
             self.dataset = wds.DataPipeline(
                 wds.SimpleShardList(
@@ -124,7 +129,10 @@ class ReferenceSmilesDM(pl.LightningDataModule):
                 wds.batched(self.batch_size, partial=False),
             )
         elif stage == "val":
-            self.dataset_size = 100000
+            if self.small_data:
+                self.dataset_size = 100
+            else:
+                self.dataset_size = 100000
             shuffle = 5000
             self.dataset = wds.DataPipeline(
                 wds.SimpleShardList(
@@ -155,7 +163,6 @@ class ReferenceSmilesDM(pl.LightningDataModule):
         )
 
         loader.length = (self.dataset_size * self.num_workers) // self.batch_size
-
         return loader
 
     def val_dataloader(self: "ReferenceSmilesDM") -> DataLoader:

--- a/src/olinda/data/reference_smiles.py
+++ b/src/olinda/data/reference_smiles.py
@@ -25,12 +25,12 @@ class ReferenceSmilesDM(pl.LightningDataModule):
 
     def __init__(
         self: "ReferenceSmilesDM",
+        num_data: int,
         workspace: Union[str, Path] = None,
         batch_size: int = 32,
         num_workers: int = 1,
         transform: Optional[Any] = None,
         target_transform: Optional[Any] = None,
-        small_data: bool = False,
     ) -> None:
         """Init.
 
@@ -48,7 +48,7 @@ class ReferenceSmilesDM(pl.LightningDataModule):
         self.num_workers = num_workers
         self.transform = transform
         self.target_transform = target_transform
-        self.small_data = small_data
+        self.num_data = num_data
 
     def prepare_data(self: "ReferenceSmilesDM") -> None:
         """Prepare data."""
@@ -111,10 +111,7 @@ class ReferenceSmilesDM(pl.LightningDataModule):
             stage (Optional[str]): Optional pipeline state
         """
         if stage == "train":
-            if self.small_data:
-                self.dataset_size = 100
-            else:
-                self.dataset_size = 1999380
+            self.dataset_size = self.num_data
             shuffle = 5000
             self.dataset = wds.DataPipeline(
                 wds.SimpleShardList(
@@ -129,10 +126,7 @@ class ReferenceSmilesDM(pl.LightningDataModule):
                 wds.batched(self.batch_size, partial=False),
             )
         elif stage == "val":
-            if self.small_data:
-                self.dataset_size = 100
-            else:
-                self.dataset_size = 100000
+            self.dataset_size = self.num_data
             shuffle = 5000
             self.dataset = wds.DataPipeline(
                 wds.SimpleShardList(
@@ -163,6 +157,7 @@ class ReferenceSmilesDM(pl.LightningDataModule):
         )
 
         loader.length = (self.dataset_size * self.num_workers) // self.batch_size
+
         return loader
 
     def val_dataloader(self: "ReferenceSmilesDM") -> DataLoader:

--- a/src/olinda/data/tensor_dataset_wrapper.py
+++ b/src/olinda/data/tensor_dataset_wrapper.py
@@ -22,7 +22,7 @@ class TensorflowDatasetWrapper:
         datamodule.setup(stage, only_X, only_Y, batched=False)
         self.dataset = datamodule.dataset
         sample = next(iter(self.dataset))
-        sample = np.array(sample)
+        #sample = np.array(sample)
 
         if stage == "train":
             self.loader = datamodule.train_dataloader()

--- a/src/olinda/distillation.py
+++ b/src/olinda/distillation.py
@@ -176,14 +176,14 @@ def gen_featurized_smiles(
         ):  
             if i < stop_step // len(batch[0]):
                 continue   
-            if i >= reference_smiles_dl.length * len(batch[1]):
+            if i >= reference_smiles_dl.length:
                 break
-                 
+                     
             output = featurizer.featurize(batch[1])
             for j, elem in enumerate(batch[0]):
                 dump((elem.tolist(), batch[1][j], output[j].tolist()), feature_stream)
 
-    featurized_smiles_dm = FeaturizedSmilesDM(Path(working_dir))
+    featurized_smiles_dm = FeaturizedSmilesDM(Path(working_dir), small_data=small_data)
     return featurized_smiles_dm
 
 
@@ -243,16 +243,16 @@ def gen_model_output(
         ):
             if i < stop_step // len(batch[0]):
                 continue
-            
+               
             if model.type == "ersilia":
                 output = model(batch[1])               
                 for j, elem in enumerate(batch[1]):
                     dump((j, elem, batch[2][j], float(output['model_score'][j])), output_stream)
+
             else:
             	output = model(torch.tensor(batch[2]))
             	for j, elem in enumerate(batch[1]):
-            	    dump((j, elem, batch[2][j], output[j].tolist()), output_stream)            
-
+            	    dump((j, elem, batch[2][j], output[j].tolist()), output_stream)           
 
     model_output_dm = GenericOutputDM(Path(working_dir / (model.name)))
     return model_output_dm

--- a/src/olinda/distillation.py
+++ b/src/olinda/distillation.py
@@ -250,9 +250,9 @@ def gen_model_output(
                 continue
                
             if model.type == "ersilia":
-                output = model(batch[1])               
+                output = model(batch[1])
                 for j, elem in enumerate(batch[1]):
-                    dump((j, elem, batch[2][j], float(output['model_score'][j])), output_stream)
+                    dump((j, elem, batch[2][j], [output[j].tolist()]), output_stream)
 
             else:
             	output = model(torch.tensor(batch[2]))

--- a/src/olinda/distillation.py
+++ b/src/olinda/distillation.py
@@ -46,7 +46,7 @@ def distill(
         featurized_smiles_dm (Optional[FeaturizedSmilesDM]): Reference Featurized SMILES datamodules.
         generic_output_dm (Optional[GenericOutputDM]): Precalculated training dataset for student model.
         test (bool): Run a test distillation on a smaller fraction of the dataset.
-
+        num_data: (int) : Set the number of ChEMBL training points to use (up to 1999380)
     Returns:
         pl.LightningModule: Student Model.
     """

--- a/src/olinda/distillation.py
+++ b/src/olinda/distillation.py
@@ -79,7 +79,7 @@ def distill(
     student_model = tuner.fit(student_training_dm)
     model_onnx = convert_to_onnx(student_model, featurizer)
 
-    return featurizer, model_onnx
+    return model_onnx
 
 
 def gen_training_dataset(

--- a/src/olinda/distillation.py
+++ b/src/olinda/distillation.py
@@ -236,9 +236,16 @@ def gen_model_output(
         ):
             if i < stop_step // len(batch[0]):
                 continue
-            output = model(torch.tensor(batch[2]))
-            for j, elem in enumerate(batch[1]):
-                dump((j, elem, batch[2][j], output[j].tolist()), output_stream)
+            
+            if model.type == "ersilia":
+                output = model(batch[1])               
+                for j, elem in enumerate(batch[1]):
+                    dump((j, elem, batch[2][j], float(output['model_score'][j])), output_stream)
+            else:
+            	output = model(torch.tensor(batch[2]))
+            	for j, elem in enumerate(batch[1]):
+            	    dump((j, elem, batch[2][j], output[j].tolist()), output_stream)            
+
 
     model_output_dm = GenericOutputDM(Path(working_dir / (model.name)))
     return model_output_dm

--- a/src/olinda/featurizer.py
+++ b/src/olinda/featurizer.py
@@ -8,6 +8,8 @@ import numpy as np
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
+import tensorflow as tf
+
 
 from olinda.utils import get_package_root_path
 
@@ -28,6 +30,7 @@ class Featurizer(ABC):
 class MorganFeaturizer(Featurizer):
     def __init__(self: "MorganFeaturizer") -> None:
         self.name = "morganfeaturizer"
+        self.tf_dtype = tf.uint8
         
     def featurize(self: "MorganFeaturizer", batch: Any) -> Any:
         """Featurize input batch.
@@ -68,6 +71,7 @@ class Flat2Grid(MorganFeaturizer):
     def __init__(self: "Flat2Grid") -> None:
         self.transformer = joblib.load(get_package_root_path() / "flat2grid.joblib")
         self.name = "flat2grid"
+        self.tf_dtype = tf.double
 
     def featurize(self: "Flat2Grid", batch: Any) -> Any:
         """Featurize input batch.

--- a/src/olinda/generic_model.py
+++ b/src/olinda/generic_model.py
@@ -46,9 +46,14 @@ class GenericModel(DistillBaseModel):
             if model[:3] == "eos":
             	self.nn = run_ersilia_api_in_context(model)
             	self.type = "ersilia"
-            	self.name = type(model).__name__.lower()
+            	self.name = self.type + "_" + model
             elif model[-5:] == ".onnx":
-                self.load(model)
+            	self.load(model)
+            #WIP ZairaChem models
+            #else:
+            #	self.nn = run_zairachem(model_path)
+            #	self.type = "zairachem"
+            #	self.name = self.type + "_" + model
 
         else:
             raise Exception(f"Unsupported Model type: {type(model)}")

--- a/src/olinda/generic_model.py
+++ b/src/olinda/generic_model.py
@@ -74,17 +74,9 @@ class GenericModel(DistillBaseModel):
             onnx.save(self.model, os.path.join(path))
         else:
             raise Exception(f"Cannot save non-ONNX model")
-    
-    def save_featurizer(self, featurizer: Any, path: str) -> None:
-        with open(os.path.join(path), "wb") as file_out:
-            pickle.dump(featurizer, file_out)
 
     def load(self: "GenericModel", path: str) -> None:
             self.model = onnx.load(os.path.join(path))
             self.nn = run_onnx_runtime(self.model)
             self.type = "onnx"
             self.name = type(self.model).__name__.lower()
-    
-    def load_featurizer(self, path: str) -> Any:
-        with open(os.path.join(path), "rb") as file_in:
-            return pickle.load(file_in)

--- a/src/olinda/generic_model.py
+++ b/src/olinda/generic_model.py
@@ -43,9 +43,12 @@ class GenericModel(DistillBaseModel):
             self.model = model
 
         elif type(model) is str:
-            self.nn = run_ersilia_api_in_context(model)
-            self.type = "ersilia"
-            self.name = type(model).__name__.lower()
+            if model[:3] == "eos":
+            	self.nn = run_ersilia_api_in_context(model)
+            	self.type = "ersilia"
+            	self.name = type(model).__name__.lower()
+            elif model[-5:] == ".onnx":
+                self.load(model)
 
         else:
             raise Exception(f"Unsupported Model type: {type(model)}")
@@ -70,3 +73,13 @@ class GenericModel(DistillBaseModel):
     def save_featurizer(self, featurizer: Any, path: str) -> None:
         with open(os.path.join(path), "wb") as file_out:
             pickle.dump(featurizer, file_out)
+
+    def load(self: "GenericModel", path: str) -> None:
+            self.model = onnx.load(os.path.join(path))
+            self.nn = run_onnx_runtime(self.model)
+            self.type = "onnx"
+            self.name = type(self.model).__name__.lower()
+    
+    def load_featurizer(self, path: str) -> Any:
+        with open(os.path.join(path), "rb") as file_in:
+            return pickle.load(file_in)

--- a/src/olinda/tuner.py
+++ b/src/olinda/tuner.py
@@ -83,7 +83,6 @@ class KerasTuner(ModelTuner):
         self.layers_range = layers_range
         self.max_epochs = max_epochs
         self.input_shape = 1024
-        self.output_shape = 1
 
     def fit(self: "KerasTuner", datamodule: GenericOutputDM) -> GenericModel:
         """Fit an optimal model using the given dataset.
@@ -101,7 +100,8 @@ class KerasTuner(ModelTuner):
             generator=train_tensor_wrapper.__iter__,
             output_signature=train_tensor_wrapper.output_signature(),
         )
-
+        
+        self.output_shape = train_tensor_wrapper.output_signature()[1].shape[0] #Length of output tensor
         val_tensor_wrapper = TensorflowDatasetWrapper(
             datamodule, "val", only_X=True, only_Y=True
         )

--- a/src/olinda/tuner.py
+++ b/src/olinda/tuner.py
@@ -114,7 +114,7 @@ class KerasTuner(ModelTuner):
         val_dataset = val_dataset.batch(32)
         self._search(train_dataset, val_dataset)
         self._get_best_epoch(train_dataset, val_dataset)
-        self._final_train(train_dataset, val_dataset)
+        #self._final_train(train_dataset, val_dataset)
         return GenericModel(self.hypermodel)
 
     def _model_builder(self: "KerasTuner", hp: Any):
@@ -180,6 +180,13 @@ class KerasTuner(ModelTuner):
         val_per_epoch = history.history["val_loss"]
         self.best_epoch = val_per_epoch.index(min(val_per_epoch)) + 1
         print("Best epoch: %d" % (self.best_epoch,))
+        
+        #FIX NEEDED: When a new model is created and trained, a Graph Execution error occurs. When overwritten here, it proceeds ok.
+        model = self.tuner.hypermodel.build(self.best_hps)
+        history = model.fit(
+            train_dataset, epochs=self.best_epoch, validation_data=val_dataset
+        )
+        self.hypermodel = model
 
     def _final_train(
         self: "KerasTuner", train_dataset: tf.data.Dataset, val_dataset: tf.data.Dataset

--- a/src/olinda/utils.py
+++ b/src/olinda/utils.py
@@ -66,8 +66,7 @@ def run_ersilia_api_in_context(model_id: str) -> Callable:
     def execute(x: Any) -> Any:       
         with ErsiliaModel(model_id) as em_api:
             tmp = em_api.run(x, output="pandas")
-            tmp['model_score'] = tmp['logPe'] #MAKE GENERAL OUTPUT ADAPTER
-            return tmp
+            return tmp['logPe']
     return execute
 
 def run_onnx_runtime(onnx_model: Any) -> Callable:

--- a/src/olinda/utils.py
+++ b/src/olinda/utils.py
@@ -2,6 +2,7 @@
 
 from io import BufferedWriter
 import os
+import numpy as np
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -9,6 +10,8 @@ from cbor2 import CBORDecoder
 from ersilia import ErsiliaModel
 import gin
 from xdg import xdg_data_home
+
+import onnxruntime as rt
 
 
 def get_package_root_path() -> Path:
@@ -65,4 +68,29 @@ def run_ersilia_api_in_context(model_id: str) -> Callable:
             tmp = em_api.run(x, output="pandas")
             tmp['model_score'] = tmp['logPe'] #MAKE GENERAL OUTPUT ADAPTER
             return tmp
+    return execute
+
+def run_onnx_runtime(onnx_model: Any) -> Callable:
+    """Utility function to execute ONNX runtime.
+
+    Args:
+        onnx_model (str): ONNX model object
+
+    Returns:
+        Callable: Util function.
+    """
+    
+    def execute(x: list) -> list:
+        onnx_rt = rt.InferenceSession(onnx_model.SerializeToString())
+        output_names = [n.name for n in onnx_model.graph.output]
+        
+        #adapt for single versus batched queries
+        if np.array(x).shape[0] == 1:
+            preds = onnx_rt.run(output_names, {"input": x})[0]
+        else:
+            preds = [onnx_rt.run(output_names, {"input": val})[0] for val in x]
+            
+        #flatten list
+        preds = [float(ele) for ele in preds]
+        return preds
     return execute

--- a/src/olinda/utils.py
+++ b/src/olinda/utils.py
@@ -66,6 +66,7 @@ def run_ersilia_api_in_context(model_id: str) -> Callable:
     def execute(x: Any) -> Any:       
         with ErsiliaModel(model_id) as em_api:
             tmp = em_api.run(x, output="pandas")
+            ###WIP: Hardcoded for eos97yu but need general output adapter
             return tmp['logPe']
     return execute
 

--- a/src/olinda/utils.py
+++ b/src/olinda/utils.py
@@ -60,8 +60,9 @@ def run_ersilia_api_in_context(model_id: str) -> Callable:
         Callable: Util function.
     """
 
-    def execute(x: Any) -> Any:
+    def execute(x: Any) -> Any:       
         with ErsiliaModel(model_id) as em_api:
-            return em_api.predict(x, output="pandas")
-
+            tmp = em_api.run(x, output="pandas")
+            tmp['model_score'] = tmp['logPe'] #MAKE GENERAL OUTPUT ADAPTER
+            return tmp
     return execute


### PR DESCRIPTION
A number of updates to get the basic functionality of Olinda working:

- Updates to dependencies to fix installation
- Switch to pure Morgan Fingerprints instead of Flat2Grid
- Implement recognition of ersilia model IDs (not general yet and deprioritised to focus on ZairaChem models)
- Distillation with a user-defined training set size for fast pipeline testing
- Conversion of distilled model to ONNX format
- Updated example notebook and documentation